### PR TITLE
Drop API 3.x support.

### DIFF
--- a/libasynql/virion.yml
+++ b/libasynql/virion.yml
@@ -4,5 +4,4 @@ authors:
 antigen: poggit\libasynql
 version: 3.3.0
 api:
-  - 3.0.0
   - 4.0.0


### PR DESCRIPTION
Due to #17, the library cannot longer support API version 3.x