### PR TITLE
Use pmmp/Snooze instead of bare-usleeping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## [3.2.1](https://github.com/poggit/libasynql/compare/v3.2.0...v3.2.0)
+## [3.3.0](https://github.com/poggit/libasynql/compare/v3.2.1...v3.3.0)
+The next minor version after 3.2.1
+
+### Added
+- Usage of pmmp/Snooze instead of usleep to fix high CPU usage
+- MySQL pings are now done before a query, if the connection is dead.
+
+## [3.2.1](https://github.com/poggit/libasynql/compare/v3.2.0...v3.2.1)
 The next patch version after 3.2.0
 
 ### Added

--- a/libasynql/src/poggit/libasynql/DataConnector.php
+++ b/libasynql/src/poggit/libasynql/DataConnector.php
@@ -121,13 +121,6 @@ interface DataConnector{
 	public function waitAll() : void;
 
 	/**
-	 * This function checks for the results of the queries handled before it was called. and proceeds to run them... check any implementation of SqlThread->readResults()
-	 *
-	 * @internal
-	 */
-	public function checkResults() : void;
-
-	/**
 	 * Closes the connection and/or all child connections. Remember to call this method when the plugin is disabled or the data provider is switched.
 	 */
 	public function close() : void;

--- a/libasynql/src/poggit/libasynql/DataConnector.php
+++ b/libasynql/src/poggit/libasynql/DataConnector.php
@@ -121,6 +121,13 @@ interface DataConnector{
 	public function waitAll() : void;
 
 	/**
+	 * This function checks for the results of the queries handled before it was called. and proceeds to run them... check any implementation of SqlThread->readResults()
+	 *
+	 * @internal
+	 */
+	public function checkResults() : void;
+
+	/**
 	 * Closes the connection and/or all child connections. Remember to call this method when the plugin is disabled or the data provider is switched.
 	 */
 	public function close() : void;

--- a/libasynql/src/poggit/libasynql/base/DataConnectorImpl.php
+++ b/libasynql/src/poggit/libasynql/base/DataConnectorImpl.php
@@ -27,7 +27,6 @@ use Exception;
 use InvalidArgumentException;
 use pocketmine\plugin\Plugin;
 use pocketmine\utils\Terminal;
-use poggit\libasynql\CallbackTask;
 use poggit\libasynql\DataConnector;
 use poggit\libasynql\generic\GenericStatementFileParser;
 use poggit\libasynql\GenericStatement;
@@ -54,11 +53,12 @@ class DataConnectorImpl implements DataConnector{
 	private $loggingQueries;
 	/** @var GenericStatement[] */
 	private $queries = [];
+	/** @var callable[] */
 	private $handlers = [];
+	/** @var int */
 	private $queryId = 0;
 	/** @var string|null */
 	private $placeHolder;
-	private $task;
 
 	/**
 	 * @param Plugin      $plugin
@@ -68,12 +68,12 @@ class DataConnectorImpl implements DataConnector{
 	 */
 	public function __construct(Plugin $plugin, SqlThread $thread, ?string $placeHolder, bool $logQueries = false){
 		$this->plugin = $plugin;
+		if($thread instanceof SqlThreadPool){
+			$thread->setDataConnector($this);
+		}
 		$this->thread = $thread;
 		$this->loggingQueries = $logQueries;
 		$this->placeHolder = $placeHolder;
-
-		$this->task = new CallbackTask([$this, "checkResults"]);
-		$this->plugin->getScheduler()->scheduleRepeatingTask($this->task, 1);
 	}
 
 	public function setLoggingQueries(bool $loggingQueries) : void{
@@ -264,6 +264,5 @@ class DataConnectorImpl implements DataConnector{
 
 	public function close() : void{
 		$this->thread->stopRunning();
-		$this->plugin->getScheduler()->cancelTask($this->task->getTaskId());
 	}
 }

--- a/libasynql/src/poggit/libasynql/base/QueueShutdownException.php
+++ b/libasynql/src/poggit/libasynql/base/QueueShutdownException.php
@@ -20,19 +20,11 @@
 
 declare(strict_types=1);
 
-namespace poggit\libasynql;
+namespace poggit\libasynql\base;
 
-use pocketmine\scheduler\Task;
 
-class CallbackTask extends Task{
-	/** @var callable */
-	protected $callback;
+use RuntimeException;
 
-	public function __construct(callable $callback){
-		$this->callback = $callback;
-	}
+class QueueShutdownException extends RuntimeException{
 
-	public function onRun(int $currentTick) : void{
-		($this->callback)();
-	}
 }

--- a/libasynql/src/poggit/libasynql/base/SqlSlaveThread.php
+++ b/libasynql/src/poggit/libasynql/base/SqlSlaveThread.php
@@ -85,9 +85,7 @@ abstract class SqlSlaveThread extends Thread implements SqlThread{
 			}catch(SqlError $error){
 				$this->bufferRecv->publishError($queryId, $error);
 			}
-			$this->synchronized(function() : void{
-				$this->notifier->wakeupSleeper();
-			});
+			$this->notifier->wakeupSleeper();
 		}
 		$this->close($resource);
 	}

--- a/libasynql/src/poggit/libasynql/generic/GenericStatementImpl.php
+++ b/libasynql/src/poggit/libasynql/generic/GenericStatementImpl.php
@@ -22,12 +22,12 @@ declare(strict_types=1);
 
 namespace poggit\libasynql\generic;
 
-use function array_key_exists;
 use AssertionError;
 use InvalidArgumentException;
 use JsonSerializable;
 use poggit\libasynql\GenericStatement;
 use poggit\libasynql\SqlDialect;
+use function array_key_exists;
 use function get_class;
 use function gettype;
 use function in_array;

--- a/libasynql/src/poggit/libasynql/mysqli/MysqlCredentials.php
+++ b/libasynql/src/poggit/libasynql/mysqli/MysqlCredentials.php
@@ -101,6 +101,20 @@ class MysqlCredentials implements JsonSerializable{
 	}
 
 	/**
+	 * Reuses an existing <a href="https://php.net/mysqli">mysqli</a> instance
+	 *
+	 * @param mysqli $mysqli
+	 *
+	 * @throws SqlError
+	 */
+	public function reconnectMysqli(mysqli &$mysqli) : void{
+		$mysqli->connect($this->host, $this->username, $this->password, $this->schema, $this->port, $this->socket);
+		if($mysqli->connect_error){
+			throw new SqlError(SqlError::STAGE_CONNECT, $mysqli->connect_error);
+		}
+	}
+
+	/**
 	 * Produces a human-readable output without leaking password
 	 *
 	 * @return string

--- a/libasynql/src/poggit/libasynql/mysqli/MysqliThread.php
+++ b/libasynql/src/poggit/libasynql/mysqli/MysqliThread.php
@@ -27,6 +27,7 @@ use InvalidArgumentException;
 use mysqli;
 use mysqli_result;
 use mysqli_stmt;
+use pocketmine\snooze\SleeperNotifier;
 use poggit\libasynql\base\QueryRecvQueue;
 use poggit\libasynql\base\QuerySendQueue;
 use poggit\libasynql\base\SqlSlaveThread;
@@ -56,13 +57,13 @@ class MysqliThread extends SqlSlaveThread{
 	private $credentials;
 
 	public static function createFactory(MysqlCredentials $credentials) : Closure{
-		return function(QuerySendQueue $bufferSend, QueryRecvQueue $bufferRecv) use ($credentials){
-			return new MysqliThread($credentials, $bufferSend, $bufferRecv);
+		return function(SleeperNotifier $notifier, QuerySendQueue $bufferSend, QueryRecvQueue $bufferRecv) use ($credentials){
+			return new MysqliThread($credentials, $notifier, $bufferSend, $bufferRecv);
 		};
 	}
 
-	public function __construct(MysqlCredentials $credentials, QuerySendQueue $bufferSend = null, QueryRecvQueue $bufferRecv = null){
-		parent::__construct($bufferSend, $bufferRecv);
+	public function __construct(MysqlCredentials $credentials, SleeperNotifier $notifier, QuerySendQueue $bufferSend = null, QueryRecvQueue $bufferRecv = null){
+		parent::__construct($notifier, $bufferSend, $bufferRecv);
 		$this->credentials = serialize($credentials);
 	}
 
@@ -79,6 +80,14 @@ class MysqliThread extends SqlSlaveThread{
 
 	protected function executeQuery($mysqli, int $mode, string $query, array $params) : SqlResult{
 		assert($mysqli instanceof mysqli);
+		while(!$mysqli->ping()){
+			/** @var MysqlCredentials $cred */
+			$cred = unserialize($this->credentials, ["allowed_classes" => [MysqlCredentials::class]]);
+			$cred->reconnectMysqli($mysqli);
+			if($this->connError === null){
+				break;
+			}
+		}
 		if(empty($params)){
 			$result = $mysqli->query($query);
 			if($result === false){
@@ -220,14 +229,6 @@ class MysqliThread extends SqlSlaveThread{
 		}
 
 		return new SqlSelectResult($columns, $rows);
-	}
-
-	protected function beforeSleep($resource, int &$sleepCount) : void{
-		if($sleepCount * 100 >= 1000000 * 60 * 5){
-			/** @var mysqli $resource */
-			$resource->ping();
-			$sleepCount = 0;
-		}
 	}
 
 	protected function close(&$mysqli) : void{

--- a/libasynql/src/poggit/libasynql/mysqli/MysqliThread.php
+++ b/libasynql/src/poggit/libasynql/mysqli/MysqliThread.php
@@ -69,7 +69,7 @@ class MysqliThread extends SqlSlaveThread{
 
 	protected function createConn(&$mysqli) : ?string{
 		/** @var MysqlCredentials $cred */
-		$cred = unserialize($this->credentials, ["allowed_classes" => [MysqlCredentials::class]]);
+		$cred = unserialize($this->credentials);
 		try{
 			$mysqli = $cred->newMysqli();
 			return null;
@@ -80,9 +80,9 @@ class MysqliThread extends SqlSlaveThread{
 
 	protected function executeQuery($mysqli, int $mode, string $query, array $params) : SqlResult{
 		assert($mysqli instanceof mysqli);
+		/** @var MysqlCredentials $cred */
+		$cred = unserialize($this->credentials);
 		while(!$mysqli->ping()){
-			/** @var MysqlCredentials $cred */
-			$cred = unserialize($this->credentials, ["allowed_classes" => [MysqlCredentials::class]]);
 			$cred->reconnectMysqli($mysqli);
 			if($this->connError === null){
 				break;

--- a/libasynql/src/poggit/libasynql/sqlite3/Sqlite3Thread.php
+++ b/libasynql/src/poggit/libasynql/sqlite3/Sqlite3Thread.php
@@ -25,6 +25,7 @@ namespace poggit\libasynql\sqlite3;
 use Closure;
 use Exception;
 use InvalidArgumentException;
+use pocketmine\snooze\SleeperNotifier;
 use poggit\libasynql\base\QueryRecvQueue;
 use poggit\libasynql\base\QuerySendQueue;
 use poggit\libasynql\base\SqlSlaveThread;
@@ -53,13 +54,13 @@ class Sqlite3Thread extends SqlSlaveThread{
 	private $path;
 
 	public static function createFactory(string $path) : Closure{
-		return function(QuerySendQueue $send, QueryRecvQueue $recv) use ($path){
-			return new Sqlite3Thread($path, $send, $recv);
+		return function(SleeperNotifier $notifier, QuerySendQueue $send, QueryRecvQueue $recv) use ($path){
+			return new Sqlite3Thread($path, $notifier, $send, $recv);
 		};
 	}
 
-	public function __construct(string $path, QuerySendQueue $send = null, QueryRecvQueue $recv = null){
-		parent::__construct($send, $recv);
+	public function __construct(string $path, SleeperNotifier $notifier, QuerySendQueue $send = null, QueryRecvQueue $recv = null){
+		parent::__construct($notifier, $send, $recv);
 		$this->path = $path;
 	}
 

--- a/libasynql/virion.yml
+++ b/libasynql/virion.yml
@@ -2,6 +2,6 @@ name: libasynql
 authors:
   - SOFe
 antigen: poggit\libasynql
-version: 3.2.1
+version: 3.3.0
 api:
   - 3.0.0


### PR DESCRIPTION
Close #15
Close #22

This change also makes it so that mysqli connections are not pinged every 5 minutes, but only if the connection is dead before a query.

Some code refactoring might be needed in the future, but this contribution aims to be as less invasive / destructive as possible.

tnx @dktapps