### PR TITLE
Fix SQLite3 returning incorrect value for SQLite3Result::columnType()

### DIFF
--- a/libasynql/src/poggit/libasynql/sqlite3/Sqlite3Thread.php
+++ b/libasynql/src/poggit/libasynql/sqlite3/Sqlite3Thread.php
@@ -109,19 +109,17 @@ class Sqlite3Thread extends SqlSlaveThread{
 			case SqlThread::MODE_SELECT:
 				/** @var SqlColumnInfo[] $colInfo */
 				$colInfo = [];
-				for($i = 0, $iMax = $result->numColumns(); $i < $iMax; ++$i){
-					static $columnTypeMap = [
-						SQLITE3_INTEGER => SqlColumnInfo::TYPE_INT,
-						SQLITE3_FLOAT => SqlColumnInfo::TYPE_FLOAT,
-						SQLITE3_TEXT => SqlColumnInfo::TYPE_STRING,
-						SQLITE3_BLOB => SqlColumnInfo::TYPE_STRING,
-						SQLITE3_NULL => SqlColumnInfo::TYPE_NULL,
-					];
-					$colInfo[] = new SqlColumnInfo($result->columnName($i), $columnTypeMap[$result->columnType($i)]);
-				}
+				static $columnTypeMap = [
+					SQLITE3_INTEGER => SqlColumnInfo::TYPE_INT,
+					SQLITE3_FLOAT => SqlColumnInfo::TYPE_FLOAT,
+					SQLITE3_TEXT => SqlColumnInfo::TYPE_STRING,
+					SQLITE3_BLOB => SqlColumnInfo::TYPE_STRING,
+					SQLITE3_NULL => SqlColumnInfo::TYPE_NULL,
+				];
 				$rows = [];
 				while(is_array($row = $result->fetchArray(SQLITE3_ASSOC))){
 					foreach(array_values($row) as $i => &$value){
+						$colInfo[$i] = new SqlColumnInfo($result->columnName($i), $columnTypeMap[$result->columnType($i)]);
 						if($colInfo[$i]->getType() === SqlColumnInfo::TYPE_FLOAT){
 							if($value === "NAN"){
 								$value = NAN;

--- a/libasynql/src/poggit/libasynql/sqlite3/Sqlite3Thread.php
+++ b/libasynql/src/poggit/libasynql/sqlite3/Sqlite3Thread.php
@@ -109,16 +109,16 @@ class Sqlite3Thread extends SqlSlaveThread{
 			case SqlThread::MODE_SELECT:
 				/** @var SqlColumnInfo[] $colInfo */
 				$colInfo = [];
-				static $columnTypeMap = [
-					SQLITE3_INTEGER => SqlColumnInfo::TYPE_INT,
-					SQLITE3_FLOAT => SqlColumnInfo::TYPE_FLOAT,
-					SQLITE3_TEXT => SqlColumnInfo::TYPE_STRING,
-					SQLITE3_BLOB => SqlColumnInfo::TYPE_STRING,
-					SQLITE3_NULL => SqlColumnInfo::TYPE_NULL,
-				];
 				$rows = [];
 				while(is_array($row = $result->fetchArray(SQLITE3_ASSOC))){
 					foreach(array_values($row) as $i => &$value){
+						static $columnTypeMap = [
+							SQLITE3_INTEGER => SqlColumnInfo::TYPE_INT,
+							SQLITE3_FLOAT => SqlColumnInfo::TYPE_FLOAT,
+							SQLITE3_TEXT => SqlColumnInfo::TYPE_STRING,
+							SQLITE3_BLOB => SqlColumnInfo::TYPE_STRING,
+							SQLITE3_NULL => SqlColumnInfo::TYPE_NULL,
+						];
 						$colInfo[$i] = new SqlColumnInfo($result->columnName($i), $columnTypeMap[$result->columnType($i)]);
 						if($colInfo[$i]->getType() === SqlColumnInfo::TYPE_FLOAT){
 							if($value === "NAN"){


### PR DESCRIPTION
When columns are checked for their types prior to `SQLite3Result::fetchArray()`, the value of `columnType()` is always `SQLITE3_NULL` (5) in PHP < 7.3.16, and `false` since PHP 7.3.16 ([causing an `undefined offset 0` error because of php's type-juggling](https://github.com/poggit/libasynql/issues/29)).
SQLite3 resolves types dynamically<sup>[[1]](https://www.sqlite.org/datatype3.html#datatypes_in_sqlite)</sup> which is possible only after a `SQLite3Result::fetchArray()` call.