### PR TITLE
Implement blob data support for SQLite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.3.1](https://github.com/poggit/libasynql/compare/v3.3.0...v3.3.1)
+The next patch version after 3.3.0
+
+### Added
+- Implemented binary string support
+
 ## [3.3.0](https://github.com/poggit/libasynql/compare/v3.2.1...v3.3.0)
 The next minor version after 3.2.1
 

--- a/libasynql/src/poggit/libasynql/generic/SqliteStatementImpl.php
+++ b/libasynql/src/poggit/libasynql/generic/SqliteStatementImpl.php
@@ -27,6 +27,7 @@ use RuntimeException;
 use SQLite3;
 use function array_map;
 use function assert;
+use function bin2hex;
 use function implode;
 use function is_array;
 use function is_bool;

--- a/libasynql/src/poggit/libasynql/generic/SqliteStatementImpl.php
+++ b/libasynql/src/poggit/libasynql/generic/SqliteStatementImpl.php
@@ -73,6 +73,9 @@ class SqliteStatementImpl extends GenericStatementImpl{
 
 			case GenericVariable::TYPE_STRING:
 				assert(is_string($value));
+				if(strstr($value, "\0") !== false){
+					return "X'" . bin2hex($value) . "'";
+				}
 				return "'" . SQLite3::escapeString($value) . "'";
 		}
 

--- a/libasynql/src/poggit/libasynql/generic/SqliteStatementImpl.php
+++ b/libasynql/src/poggit/libasynql/generic/SqliteStatementImpl.php
@@ -73,7 +73,7 @@ class SqliteStatementImpl extends GenericStatementImpl{
 
 			case GenericVariable::TYPE_STRING:
 				assert(is_string($value));
-				if(strstr($value, "\0") !== false){
+				if(strpos($value, "\0") !== false){
 					return "X'" . bin2hex($value) . "'";
 				}
 				return "'" . SQLite3::escapeString($value) . "'";

--- a/libasynql/src/poggit/libasynql/generic/SqliteStatementImpl.php
+++ b/libasynql/src/poggit/libasynql/generic/SqliteStatementImpl.php
@@ -33,6 +33,7 @@ use function is_bool;
 use function is_float;
 use function is_int;
 use function is_string;
+use function strpos;
 
 class SqliteStatementImpl extends GenericStatementImpl{
 	public function getDialect() : string{

--- a/libasynql/virion.yml
+++ b/libasynql/virion.yml
@@ -2,6 +2,6 @@ name: libasynql
 authors:
   - SOFe
 antigen: poggit\libasynql
-version: 3.3.0
+version: 3.3.1
 api:
   - 3.0.0


### PR DESCRIPTION
[`SQLite3::escapeString()`](https://www.php.net/manual/en/sqlite3.escapestring.php) currently is not binary-safe, which causes blob data to be encoded into the final query incorrectly.

This can be tested by inserting binary data (with `\0` a.k.a. the `NULL` character) into a blob column.

Without this patch, it would only insert the first-n bytes before a `\0` is encountered.

Before: 
![image](https://user-images.githubusercontent.com/17762324/85442253-8e114200-b5c2-11ea-9746-1879d4ff63df.png)

After: 
![image](https://user-images.githubusercontent.com/17762324/85442295-a1241200-b5c2-11ea-9442-7417fc1c71aa.png)

