### PR TITLE
Added missing parent::quit() in SqlSlaveThread.

### DIFF
--- a/libasynql/src/poggit/libasynql/base/SqlSlaveThread.php
+++ b/libasynql/src/poggit/libasynql/base/SqlSlaveThread.php
@@ -102,6 +102,8 @@ abstract class SqlSlaveThread extends Thread implements SqlThread{
 
 	public function stopRunning() : void{
 		$this->bufferSend->invalidate();
+
+		parent::quit();
 	}
 
 	public function quit(){


### PR DESCRIPTION
This method is required in order to know that the thread has successfully being destroyed. Without this, pocketmine would think that the thread is still running and finally causing a heap of unknown/killed threads.

## Steps to reproduce
Here is an example of how to create the such issue stated above.
```php
for($i = 0; $i <= 5; $i++){
	$db = libasynql::create($this, [
		"type"   => "sqlite",
		"sqlite" => "data.db",
	], [
		"sqlite" => "temp.sql",
	]);

	$db->executeGeneric("dummy");
	$db->waitAll();
	$db->close();
}

foreach(ThreadManager::getInstance()->getAll() as $worker){
	var_dump($worker->getThreadName());
}
```
_Another way to reproduce this issue is to `reload` the server multiple times and issue a `status` command_
### Results:
Before this commit:
![unknown](https://user-images.githubusercontent.com/15889642/89104860-033c2680-d44f-11ea-8631-a6769ce5acf3.png)
After this commit:
![unknown](https://user-images.githubusercontent.com/15889642/89104869-10f1ac00-d44f-11ea-8837-5cba16983979.png)
