### PR TITLE
Replace curly braces with brackets

### DIFF
--- a/libasynql/cli/def.php
+++ b/libasynql/cli/def.php
@@ -152,7 +152,7 @@ fwrite($fh, $STRUCT . ' ' . array_slice($fqnPieces, -1)[0] . '{' . $EOL);
 $constLog = [];
 foreach($results as $queryName => $stmts){
 	$const = preg_replace('/[^A-Z0-9]+/i', "_", strtoupper($queryName));
-	if(ctype_digit($queryName{0})){
+	if(ctype_digit($queryName[0])){
 		$const = "_" . $const;
 	}
 	if(isset($constLog[$const])){

--- a/libasynql/src/poggit/libasynql/generic/GenericStatementFileParser.php
+++ b/libasynql/src/poggit/libasynql/generic/GenericStatementFileParser.php
@@ -124,7 +124,7 @@ class GenericStatementFileParser{
 		if($line === ''){
 			return true;
 		}
-		$cmd = $line{0};
+		$cmd = $line[0];
 		$args = [];
 		$argOffsets = [];
 		$regex = /** @lang RegExp */

--- a/libasynql/src/poggit/libasynql/generic/GenericVariable.php
+++ b/libasynql/src/poggit/libasynql/generic/GenericVariable.php
@@ -70,7 +70,7 @@ class GenericVariable implements JsonSerializable{
 			$this->canEmpty = true;
 			/** @noinspection CallableParameterUseCaseInTypeContextInspection */
 			$type = substr($type, strlen("list?"));
-		}elseif($type{0} === "?"){
+		}elseif($type[0] === "?"){
 			$this->nullable = true;
 			$type = substr($type, 1);
 		}
@@ -81,7 +81,7 @@ class GenericVariable implements JsonSerializable{
 			}
 			switch($type){
 				case self::TYPE_STRING:
-					if($default{0} === "\"" && $default{strlen($default) - 1} === "\""){
+					if($default[0] === "\"" && $default[strlen($default) - 1] === "\""){
 						$default = json_decode($default);
 						assert(is_string($default));
 					}

--- a/libasynql/src/poggit/libasynql/libasynql.php
+++ b/libasynql/src/poggit/libasynql/libasynql.php
@@ -150,11 +150,11 @@ final class libasynql{
 	}
 
 	private static function resolvePath(string $folder, string $path) : string{
-		if($path{0} === "/"){
+		if($path[0] === "/"){
 			return $path;
 		}
 		if(Utils::getOS() === "win"){
-			if($path{0} === "\\" || $path{1} === ":"){
+			if($path[0] === "\\" || $path[1] === ":"){
 				return $path;
 			}
 		}


### PR DESCRIPTION
Array and string offset access syntax with curly braces are deprecated in PHP 7.4