### PR TITLE
Return null instead of passing null to str_replace

### DIFF
--- a/libasynql/src/poggit/libasynql/generic/GenericStatementImpl.php
+++ b/libasynql/src/poggit/libasynql/generic/GenericStatementImpl.php
@@ -103,7 +103,7 @@ abstract class GenericStatementImpl implements GenericStatement, JsonSerializabl
 		$this->query = $query;
 		$this->doc = $doc;
 		$this->variables = $variables;
-		$this->file = str_replace("\\", "/", $file);
+		$this->file = $file !== null ? str_replace("\\", "/", $file) : null;
 		$this->lineNo = $lineNo;
 
 		$this->compilePositions();


### PR DESCRIPTION
In PHP8, you cannot pass nulls where nulls aren't accepted, whereas PHP7 would just take it, this PR returns null rather than passing a null through to str_replace