### PR TITLE
PM4: CommonThreadPartsTrait::setClassLoaders() change

### DIFF
--- a/libasynql/src/poggit/libasynql/base/SqlSlaveThread.php
+++ b/libasynql/src/poggit/libasynql/base/SqlSlaveThread.php
@@ -59,13 +59,12 @@ abstract class SqlSlaveThread extends Thread implements SqlThread{
 			/** @noinspection NullPointerExceptionInspection */
 			/** @var ClassLoader $cl */
 			$cl = Server::getInstance()->getPluginManager()->getPlugin("DEVirion")->getVirionClassLoader();
-			$this->setClassLoader($cl);
+			$this->setClassLoaders([Server::getInstance()->getLoader(), $cl]);
 		}
 		$this->start(PTHREADS_INHERIT_INI | PTHREADS_INHERIT_CONSTANTS);
 	}
 
 	protected function onRun() : void{
-		$this->registerClassLoader();
 		$error = $this->createConn($resource);
 		$this->connCreated = true;
 		$this->connError = $error;


### PR DESCRIPTION
Recently, PM4 removed `CommonThreadPartsTrait::setClassLoader(?ClassLoader)` and added `CommonThreadPartsTrait::setClassLoaders(?ClassLoader[])` which appends an array of class loaders to existing class loaders of a given thread (https://github.com/pmmp/PocketMine-MP/commit/5fbc7681b04fe702fcbd43940b9d325e5c216707).

This PR registers two class loaders onto `SqlSlaveThread` — `Server::getInstance()->getLoader()` (to load DEVirion plugin's VirionClassLoader class) and DEVirion's class loader (to load virions classes) when running in a dev environment (`!libasynql::isPackaged()`).

This PR removes `CommonThreadPartsTrait::registerClassLoader()` method call from `SqlSlaveThread::onRun()` as CommonThreadPartsTrait calls this method by itself in it's `final CommonThreadPartsTrait::run()` method before it calls `CommonThreadPartsTrait::onRun()` (or in this case, `SqlSlaveThread::onRun()`).

Related Issues:
- #62 