### PR TITLE
Fixed str_replace() in case of null file value

### DIFF
--- a/libasynql/src/poggit/libasynql/generic/GenericStatementImpl.php
+++ b/libasynql/src/poggit/libasynql/generic/GenericStatementImpl.php
@@ -103,7 +103,7 @@ abstract class GenericStatementImpl implements GenericStatement, JsonSerializabl
 		$this->query = $query;
 		$this->doc = $doc;
 		$this->variables = $variables;
-		$this->file = str_replace("\\", "/", $file);
+		$this->file = $file !== null ? str_replace("\\", "/", $file) : null;
 		$this->lineNo = $lineNo;
 
 		$this->compilePositions();

--- a/libasynql/virion.yml
+++ b/libasynql/virion.yml
@@ -2,6 +2,6 @@ name: libasynql
 authors:
   - SOFe
 antigen: poggit\libasynql
-version: 3.3.1
+version: 3.3.2
 api:
   - 3.0.0


### PR DESCRIPTION
With PHP8 passing a null value to `$file` causes an exception. This PR aims to fix it.