### PR TITLE
DataConnectorImpl->waitAll() now waits for results

### DIFF
--- a/libasynql/src/poggit/libasynql/base/DataConnectorImpl.php
+++ b/libasynql/src/poggit/libasynql/base/DataConnectorImpl.php
@@ -315,7 +315,6 @@ class DataConnectorImpl implements DataConnector{
 	public function waitAll() : void{
 		while(!empty($this->handlers)){
 			$this->checkResults();
-			usleep(1000);
 		}
 	}
 

--- a/libasynql/src/poggit/libasynql/base/QuerySendQueue.php
+++ b/libasynql/src/poggit/libasynql/base/QuerySendQueue.php
@@ -67,4 +67,8 @@ class QuerySendQueue extends Threaded{
 	public function isInvalidated(): bool {
 		return $this->invalidated;
 	}
+
+	public function getQueriesCount() : int{
+		return $this->queries->count();
+	}
 }

--- a/libasynql/src/poggit/libasynql/base/QuerySendQueue.php
+++ b/libasynql/src/poggit/libasynql/base/QuerySendQueue.php
@@ -67,8 +67,4 @@ class QuerySendQueue extends Threaded{
 	public function isInvalidated(): bool {
 		return $this->invalidated;
 	}
-
-	public function getQueriesCount() : int{
-		return $this->queries->count();
-	}
 }

--- a/libasynql/src/poggit/libasynql/base/SqlSlaveThread.php
+++ b/libasynql/src/poggit/libasynql/base/SqlSlaveThread.php
@@ -54,6 +54,7 @@ abstract class SqlSlaveThread extends Thread implements SqlThread{
 		$this->slaveNumber = self::$nextSlaveNumber++;
 		$this->bufferSend = $bufferSend ?? new QuerySendQueue();
 		$this->bufferRecv = $bufferRecv ?? new QueryRecvQueue();
+		$this->bufferRecv->addAvailableThread();
 
 		if(!libasynql::isPackaged()){
 			/** @noinspection PhpUndefinedMethodInspection */
@@ -75,7 +76,9 @@ abstract class SqlSlaveThread extends Thread implements SqlThread{
 		}
 
 		while(true){
+			$this->bufferRecv->removeAvailableThread();
 			$row = $this->bufferSend->fetchQuery();
+			$this->bufferRecv->addAvailableThread();
 			if(!is_string($row)){
 				break;
 			}
@@ -95,6 +98,7 @@ abstract class SqlSlaveThread extends Thread implements SqlThread{
 			$this->notifier->wakeupSleeper();
 			$this->busy = false;
 		}
+		$this->bufferRecv->removeAvailableThread();
 		$this->close($resource);
 	}
 
@@ -121,9 +125,6 @@ abstract class SqlSlaveThread extends Thread implements SqlThread{
 	}
 
 	public function readResults(array &$callbacks) : void{
-		if($this->bufferRecv->count() === 0 && $this->bufferSend->getQueriesCount() === 0){
-			return;
-		}
 		while($this->bufferRecv->waitForResults($queryId, $results)){
 			if(!isset($callbacks[$queryId])){
 				throw new InvalidArgumentException("Missing handler for query #$queryId");

--- a/libasynql/src/poggit/libasynql/base/SqlSlaveThread.php
+++ b/libasynql/src/poggit/libasynql/base/SqlSlaveThread.php
@@ -121,7 +121,10 @@ abstract class SqlSlaveThread extends Thread implements SqlThread{
 	}
 
 	public function readResults(array &$callbacks) : void{
-		while($this->bufferRecv->fetchResults($queryId, $results)){
+		if($this->bufferRecv->count() === 0 && $this->bufferSend->getQueriesCount() === 0){
+			return;
+		}
+		while($this->bufferRecv->waitForResults($queryId, $results)){
 			if(!isset($callbacks[$queryId])){
 				throw new InvalidArgumentException("Missing handler for query #$queryId");
 			}

--- a/libasynql/src/poggit/libasynql/base/SqlThreadPool.php
+++ b/libasynql/src/poggit/libasynql/base/SqlThreadPool.php
@@ -104,9 +104,6 @@ class SqlThreadPool implements SqlThread{
 	}
 
 	public function readResults(array &$callbacks) : void{
-		if($this->bufferRecv->count() === 0 && $this->bufferSend->getQueriesCount() === 0){
-			return;
-		}
 		while($this->bufferRecv->waitForResults($queryId, $results)){
 			if(!isset($callbacks[$queryId])){
 				throw new InvalidArgumentException("Missing handler for query #$queryId");

--- a/libasynql/src/poggit/libasynql/base/SqlThreadPool.php
+++ b/libasynql/src/poggit/libasynql/base/SqlThreadPool.php
@@ -104,7 +104,10 @@ class SqlThreadPool implements SqlThread{
 	}
 
 	public function readResults(array &$callbacks) : void{
-		while($this->bufferRecv->fetchResults($queryId, $results)){
+		if($this->bufferRecv->count() === 0 && $this->bufferSend->getQueriesCount() === 0){
+			return;
+		}
+		while($this->bufferRecv->waitForResults($queryId, $results)){
 			if(!isset($callbacks[$queryId])){
 				throw new InvalidArgumentException("Missing handler for query #$queryId");
 			}


### PR DESCRIPTION
`DataConnectorImpl->waitAll()` uses `usleep` and a while loop to receive data from other threads which it might affect the CPU by looping an unnecessary amount of times. This pull request changes it so it now waits for data using `wait()` and `notify()` in `QueryRecvQueue` by adding a new method called `waitForResults`. This method could be merged into `fetchResults` but it only returns `false` if there are no available threads to receive data from.