### PR TITLE
fix array keys being lost in sqlite3

### DIFF
--- a/libasynql/src/poggit/libasynql/sqlite3/Sqlite3Thread.php
+++ b/libasynql/src/poggit/libasynql/sqlite3/Sqlite3Thread.php
@@ -111,7 +111,6 @@ class Sqlite3Thread extends SqlSlaveThread{
 				$colInfo = [];
 				$rows = [];
 				while(is_array($row = $result->fetchArray(SQLITE3_ASSOC))){
-					$row = array_values($row);
 					foreach($row as $i => &$value){
 						static $columnTypeMap = [
 							SQLITE3_INTEGER => SqlColumnInfo::TYPE_INT,

--- a/libasynql/src/poggit/libasynql/sqlite3/Sqlite3Thread.php
+++ b/libasynql/src/poggit/libasynql/sqlite3/Sqlite3Thread.php
@@ -111,7 +111,7 @@ class Sqlite3Thread extends SqlSlaveThread{
 				$colInfo = [];
 				$rows = [];
 				while(is_array($row = $result->fetchArray(SQLITE3_ASSOC))){
-					foreach($row as $i => &$value){
+					foreach(array_values($row) as $i => &$value){
 						static $columnTypeMap = [
 							SQLITE3_INTEGER => SqlColumnInfo::TYPE_INT,
 							SQLITE3_FLOAT => SqlColumnInfo::TYPE_FLOAT,


### PR DESCRIPTION
This fixes SqlSelectResult when using sqlite3.