### PR TITLE
Fixed PHP 8.1 error

### DIFF
--- a/libasynql/src/poggit/libasynql/generic/GenericStatementImpl.php
+++ b/libasynql/src/poggit/libasynql/generic/GenericStatementImpl.php
@@ -230,7 +230,7 @@ abstract class GenericStatementImpl implements GenericStatement, JsonSerializabl
 
 	protected abstract function formatVariable(GenericVariable $variable, $value, ?string $placeHolder, array &$outArgs) : string;
 
-	public function jsonSerialize(){
+	public function jsonSerialize(): array {
 		return [
 			"name" => $this->name,
 			"query" => $this->query,


### PR DESCRIPTION
PHP 8.1 will throw an exception if `jsonSerialize()` don't have a return-type. This PR fixes this.