### PR TITLE
Fixed queries not executing until the next sleeper wakeup

### DIFF
--- a/libasynql/src/poggit/libasynql/SqlThread.php
+++ b/libasynql/src/poggit/libasynql/SqlThread.php
@@ -54,8 +54,9 @@ interface SqlThread{
 	 * Handles the results that this query has completed
 	 *
 	 * @param callable[] $callbacks
+	 * @param int|null $expectedResults
 	 */
-	public function readResults(array &$callbacks) : void;
+	public function readResults(array &$callbacks, ?int $expectedResults) : void;
 
 	/**
 	 * Checks if the initial connection has been made, no matter successful or not.

--- a/libasynql/src/poggit/libasynql/base/DataConnectorImpl.php
+++ b/libasynql/src/poggit/libasynql/base/DataConnectorImpl.php
@@ -314,12 +314,12 @@ class DataConnectorImpl implements DataConnector{
 
 	public function waitAll() : void{
 		while(!empty($this->handlers)){
-			$this->checkResults();
+			$this->thread->readResults($this->handlers, count($this->handlers));
 		}
 	}
 
 	public function checkResults() : void{
-		$this->thread->readResults($this->handlers);
+		$this->thread->readResults($this->handlers, null);
 	}
 
 	public function close() : void{

--- a/libasynql/src/poggit/libasynql/base/QueryRecvQueue.php
+++ b/libasynql/src/poggit/libasynql/base/QueryRecvQueue.php
@@ -50,12 +50,12 @@ class QueryRecvQueue extends Threaded{
 	}
 
 	public function fetchResults(&$queryId, &$results) : bool{
-		if($this->count() > 0){
-			while(($row = $this->shift()) === null);
-			[$queryId, $results] = unserialize($row, ["allowed_classes" => true]);
-			return true;
+		while(is_int($row = $this->shift())); //Somehow $this->availableThreads are here, so we have to remove them. TODO: Remove available threads in the next major update.
+		if($row === null){
+			return false;
 		}
-		return false;
+		[$queryId, $results] = unserialize($row, ["allowed_classes" => true]);
+		return true;
 	}
 
 	/**

--- a/libasynql/src/poggit/libasynql/base/QueryRecvQueue.php
+++ b/libasynql/src/poggit/libasynql/base/QueryRecvQueue.php
@@ -50,12 +50,10 @@ class QueryRecvQueue extends Threaded{
 	}
 
 	public function fetchResults(&$queryId, &$results) : bool{
-		while($this->count() > 0){
-			$row = $this->shift();
-			if(is_string($row)){
-				[$queryId, $results] = unserialize($row, ["allowed_classes" => true]);
-				return true;
-			}
+		if($this->count() > 0){
+			while(($row = $this->shift()) === null);
+			[$queryId, $results] = unserialize($row, ["allowed_classes" => true]);
+			return true;
 		}
 		return false;
 	}

--- a/libasynql/src/poggit/libasynql/base/QueryRecvQueue.php
+++ b/libasynql/src/poggit/libasynql/base/QueryRecvQueue.php
@@ -50,10 +50,12 @@ class QueryRecvQueue extends Threaded{
 	}
 
 	public function fetchResults(&$queryId, &$results) : bool{
-		$row = $this->shift();
-		if(is_string($row)){
-			[$queryId, $results] = unserialize($row, ["allowed_classes" => true]);
-			return true;
+		while($this->count() > 0){
+			$row = $this->shift();
+			if(is_string($row)){
+				[$queryId, $results] = unserialize($row, ["allowed_classes" => true]);
+				return true;
+			}
 		}
 		return false;
 	}

--- a/libasynql/src/poggit/libasynql/base/SqlSlaveThread.php
+++ b/libasynql/src/poggit/libasynql/base/SqlSlaveThread.php
@@ -54,7 +54,6 @@ abstract class SqlSlaveThread extends Thread implements SqlThread{
 		$this->slaveNumber = self::$nextSlaveNumber++;
 		$this->bufferSend = $bufferSend ?? new QuerySendQueue();
 		$this->bufferRecv = $bufferRecv ?? new QueryRecvQueue();
-		$this->bufferRecv->addAvailableThread();
 
 		if(!libasynql::isPackaged()){
 			/** @noinspection PhpUndefinedMethodInspection */
@@ -76,9 +75,7 @@ abstract class SqlSlaveThread extends Thread implements SqlThread{
 		}
 
 		while(true){
-			$this->bufferRecv->removeAvailableThread();
 			$row = $this->bufferSend->fetchQuery();
-			$this->bufferRecv->addAvailableThread();
 			if(!is_string($row)){
 				break;
 			}
@@ -98,7 +95,6 @@ abstract class SqlSlaveThread extends Thread implements SqlThread{
 			$this->notifier->wakeupSleeper();
 			$this->busy = false;
 		}
-		$this->bufferRecv->removeAvailableThread();
 		$this->close($resource);
 	}
 

--- a/libasynql/src/poggit/libasynql/base/SqlSlaveThread.php
+++ b/libasynql/src/poggit/libasynql/base/SqlSlaveThread.php
@@ -120,8 +120,13 @@ abstract class SqlSlaveThread extends Thread implements SqlThread{
 		$this->bufferSend->scheduleQuery($queryId, $modes, $queries, $params);
 	}
 
-	public function readResults(array &$callbacks) : void{
-		while($this->bufferRecv->waitForResults($queryId, $results)){
+	public function readResults(array &$callbacks, ?int $expectedResults) : void{
+		if($expectedResults === null){
+			$resultsList = $this->bufferRecv->fetchAllResults();
+		}else{
+			$resultsList = $this->bufferRecv->waitForResults($expectedResults);
+		}
+		foreach($resultsList as [$queryId, $results]){
 			if(!isset($callbacks[$queryId])){
 				throw new InvalidArgumentException("Missing handler for query #$queryId");
 			}

--- a/libasynql/src/poggit/libasynql/base/SqlThreadPool.php
+++ b/libasynql/src/poggit/libasynql/base/SqlThreadPool.php
@@ -103,8 +103,13 @@ class SqlThreadPool implements SqlThread{
 		}
 	}
 
-	public function readResults(array &$callbacks) : void{
-		while($this->bufferRecv->waitForResults($queryId, $results)){
+	public function readResults(array &$callbacks, ?int $expectedResults) : void{
+		if($expectedResults === null){
+			$resultsList = $this->bufferRecv->fetchAllResults();
+		}else{
+			$resultsList = $this->bufferRecv->waitForResults($expectedResults);
+		}
+		foreach($resultsList as [$queryId, $results]){
 			if(!isset($callbacks[$queryId])){
 				throw new InvalidArgumentException("Missing handler for query #$queryId");
 			}


### PR DESCRIPTION
Apparently `Threaded->count()` and `Threaded->shift()` are not synchronized with each other and that was the cause of the issue.
Fixes #90 