### PR TITLE
Implement SSL Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ database:
     username: root
     password: ""
     schema: your_schema
+    # SSL support
+    ssl:
+      ca-certificate: /etc/ssl/certs/ca-certificates.crt
   # The maximum number of simultaneous SQL queries
   # Recommended: 1 for sqlite, 2 for MySQL. You may want to further increase this value if your MySQL connection is very slow.
   worker-limit: 1

--- a/README.md
+++ b/README.md
@@ -35,9 +35,6 @@ database:
     username: root
     password: ""
     schema: your_schema
-    # SSL support
-    ssl:
-      ca-certificate: /etc/ssl/certs/ca-certificates.crt
   # The maximum number of simultaneous SQL queries
   # Recommended: 1 for sqlite, 2 for MySQL. You may want to further increase this value if your MySQL connection is very slow.
   worker-limit: 1

--- a/libasynql/src/poggit/libasynql/mysqli/MysqlCredentials.php
+++ b/libasynql/src/poggit/libasynql/mysqli/MysqlCredentials.php
@@ -106,8 +106,7 @@ class MysqlCredentials implements JsonSerializable{
 	 *
 	 * @throws SqlError
 	 */
-	public function newMysqli(): mysqli
-	{
+	public function newMysqli() : mysqli{
 		$mysqli = mysqli_init();
 		if ($mysqli === false) {
 			throw new SqlError(SqlError::STAGE_CONNECT, "Failed to initialize mysqli");
@@ -129,8 +128,7 @@ class MysqlCredentials implements JsonSerializable{
 	 *
 	 * @throws SqlError
 	 */
-	public function reconnectMysqli(mysqli $mysqli): void
-	{
+	public function reconnectMysqli(mysqli $mysqli) : void{
 		@mysqli_real_connect($mysqli, $this->host, $this->username, $this->password, $this->schema, $this->port, $this->socket);
 		if ($mysqli->connect_error) {
 			throw new SqlError(SqlError::STAGE_CONNECT, $mysqli->connect_error);
@@ -142,8 +140,7 @@ class MysqlCredentials implements JsonSerializable{
 	 *
 	 * @return string
 	 */
-	public function __toString(): string
-	{
+	public function __toString() : string{
 		return "$this->username@$this->host:$this->port/schema,$this->socket";
 	}
 
@@ -152,8 +149,7 @@ class MysqlCredentials implements JsonSerializable{
 	 *
 	 * @return array
 	 */
-	public function __debugInfo()
-	{
+	public function __debugInfo(){
 		return [
 			"host" => $this->host,
 			"username" => $this->username,
@@ -165,8 +161,7 @@ class MysqlCredentials implements JsonSerializable{
 		];
 	}
 
-	public function jsonSerialize(): array
-	{
+	public function jsonSerialize() : array{
 		return [
 			"host" => $this->host,
 			"username" => $this->username,

--- a/libasynql/src/poggit/libasynql/mysqli/MysqlCredentials.php
+++ b/libasynql/src/poggit/libasynql/mysqli/MysqlCredentials.php
@@ -63,7 +63,7 @@ class MysqlCredentials implements JsonSerializable{
 	 */
 	public static function fromArray(array $array, ?string $defaultSchema = null): MysqlCredentials
 	{
-		if (!isset($defaultSchema, $array["schema"])) {
+		if(!isset($defaultSchema, $array["schema"])) {
 			throw new ConfigException("The attribute \"schema\" is missing in the MySQL settings");
 		}
 		return new MysqlCredentials(
@@ -108,14 +108,14 @@ class MysqlCredentials implements JsonSerializable{
 	 */
 	public function newMysqli() : mysqli{
 		$mysqli = mysqli_init();
-		if ($mysqli === false) {
+		if($mysqli === false) {
 			throw new SqlError(SqlError::STAGE_CONNECT, "Failed to initialize mysqli");
 		}
-		if ($this->sslCredentials !== null) {
+		if($this->sslCredentials !== null) {
 			$this->sslCredentials->applyToInstance($mysqli);
 		}
 		@mysqli_real_connect($mysqli, $this->host, $this->username, $this->password, $this->schema, $this->port, $this->socket);
-		if ($mysqli->connect_error) {
+		if($mysqli->connect_error) {
 			throw new SqlError(SqlError::STAGE_CONNECT, $mysqli->connect_error);
 		}
 		return $mysqli;
@@ -130,7 +130,7 @@ class MysqlCredentials implements JsonSerializable{
 	 */
 	public function reconnectMysqli(mysqli $mysqli) : void{
 		@mysqli_real_connect($mysqli, $this->host, $this->username, $this->password, $this->schema, $this->port, $this->socket);
-		if ($mysqli->connect_error) {
+		if($mysqli->connect_error) {
 			throw new SqlError(SqlError::STAGE_CONNECT, $mysqli->connect_error);
 		}
 	}

--- a/libasynql/src/poggit/libasynql/mysqli/MysqlCredentials.php
+++ b/libasynql/src/poggit/libasynql/mysqli/MysqlCredentials.php
@@ -62,7 +62,7 @@ class MysqlCredentials implements JsonSerializable{
 	 * @throws ConfigException If <code>schema</code> is missing and <code>$defaultSchema</code> is null/not passed
 	 */
 	public static function fromArray(array $array, ?string $defaultSchema = null) : MysqlCredentials{
-		if(!isset($defaultSchema, $array["schema"])) {
+		if(!isset($defaultSchema, $array["schema"])){
 			throw new ConfigException("The attribute \"schema\" is missing in the MySQL settings");
 		}
 		return new MysqlCredentials(
@@ -106,14 +106,14 @@ class MysqlCredentials implements JsonSerializable{
 	 */
 	public function newMysqli() : mysqli{
 		$mysqli = mysqli_init();
-		if($mysqli === false) {
+		if($mysqli === false){
 			throw new SqlError(SqlError::STAGE_CONNECT, "Failed to initialize mysqli");
 		}
-		if($this->sslCredentials !== null) {
+		if($this->sslCredentials !== null){
 			$this->sslCredentials->applyToInstance($mysqli);
 		}
 		@mysqli_real_connect($mysqli, $this->host, $this->username, $this->password, $this->schema, $this->port, $this->socket);
-		if($mysqli->connect_error) {
+		if($mysqli->connect_error){
 			throw new SqlError(SqlError::STAGE_CONNECT, $mysqli->connect_error);
 		}
 		return $mysqli;
@@ -128,7 +128,7 @@ class MysqlCredentials implements JsonSerializable{
 	 */
 	public function reconnectMysqli(mysqli $mysqli) : void{
 		@mysqli_real_connect($mysqli, $this->host, $this->username, $this->password, $this->schema, $this->port, $this->socket);
-		if($mysqli->connect_error) {
+		if($mysqli->connect_error){
 			throw new SqlError(SqlError::STAGE_CONNECT, $mysqli->connect_error);
 		}
 	}

--- a/libasynql/src/poggit/libasynql/mysqli/MysqlCredentials.php
+++ b/libasynql/src/poggit/libasynql/mysqli/MysqlCredentials.php
@@ -28,8 +28,7 @@ use poggit\libasynql\ConfigException;
 use poggit\libasynql\SqlError;
 use function strlen;
 
-class MysqlCredentials implements JsonSerializable
-{
+class MysqlCredentials implements JsonSerializable{
 	/** @var string $host */
 	private $host;
 	/** @var string $username */
@@ -42,7 +41,7 @@ class MysqlCredentials implements JsonSerializable
 	private $port;
 	/** @var string $socket */
 	private $socket;
-	/** @var MysqlSslCredentials */
+	/** @var MysqlSslCredentials|null */
 	private $sslCredentials;
 
 

--- a/libasynql/src/poggit/libasynql/mysqli/MysqlCredentials.php
+++ b/libasynql/src/poggit/libasynql/mysqli/MysqlCredentials.php
@@ -61,8 +61,7 @@ class MysqlCredentials implements JsonSerializable{
 	 * @return MysqlCredentials
 	 * @throws ConfigException If <code>schema</code> is missing and <code>$defaultSchema</code> is null/not passed
 	 */
-	public static function fromArray(array $array, ?string $defaultSchema = null): MysqlCredentials
-	{
+	public static function fromArray(array $array, ?string $defaultSchema = null) : MysqlCredentials{
 		if(!isset($defaultSchema, $array["schema"])) {
 			throw new ConfigException("The attribute \"schema\" is missing in the MySQL settings");
 		}
@@ -88,8 +87,7 @@ class MysqlCredentials implements JsonSerializable{
 	 * @param string $socket
 	 * @param MysqlSslCredentials|null $sslCredentials
 	 */
-	public function __construct(string $host, string $username, string $password, string $schema, int $port = 3306, string $socket = "", ?MysqlSslCredentials $sslCredentials = null)
-	{
+	public function __construct(string $host, string $username, string $password, string $schema, int $port = 3306, string $socket = "", ?MysqlSslCredentials $sslCredentials = null){
 		$this->host = $host;
 		$this->username = $username;
 		$this->password = $password;

--- a/libasynql/src/poggit/libasynql/mysqli/MysqlCredentials.php
+++ b/libasynql/src/poggit/libasynql/mysqli/MysqlCredentials.php
@@ -72,7 +72,7 @@ class MysqlCredentials implements JsonSerializable{
 			$array["schema"] ?? $defaultSchema,
 			$array["port"] ?? 3306,
 			$array["socket"] ?? "",
-			isset($array["ssl"]) ? MysqlSslCredentials::fromArray($array["ssl"]) : null
+			isset($array["ssl"]) ? MysqlSslCredentials::fromArray($array["ssl"]) : null,
 		);
 	}
 
@@ -155,7 +155,7 @@ class MysqlCredentials implements JsonSerializable{
 			"schema" => $this->schema,
 			"port" => $this->port,
 			"socket" => $this->socket,
-			"sslCredentials" => $this->sslCredentials
+			"sslCredentials" => $this->sslCredentials,
 		];
 	}
 
@@ -167,7 +167,7 @@ class MysqlCredentials implements JsonSerializable{
 			"schema" => $this->schema,
 			"port" => $this->port,
 			"socket" => $this->socket,
-			"sslCredentials" => $this->sslCredentials
+			"sslCredentials" => $this->sslCredentials,
 		];
 	}
 }

--- a/libasynql/src/poggit/libasynql/mysqli/MysqlSslCredentials.php
+++ b/libasynql/src/poggit/libasynql/mysqli/MysqlSslCredentials.php
@@ -25,8 +25,7 @@ namespace poggit\libasynql\mysqli;
 use JsonSerializable;
 use mysqli;
 
-class MysqlSslCredentials implements JsonSerializable
-{
+class MysqlSslCredentials implements JsonSerializable{
 	/** @var string $key */
 	private $key;
 	/** @var string $certificate */

--- a/libasynql/src/poggit/libasynql/mysqli/MysqlSslCredentials.php
+++ b/libasynql/src/poggit/libasynql/mysqli/MysqlSslCredentials.php
@@ -55,7 +55,7 @@ class MysqlSslCredentials implements JsonSerializable{
 	}
 
 	/**
-	 * Constructs a new {@link MysqlCredentials} by passing parameters directly.
+	 * Constructs a new {@link MysqlSslCredentials} by passing parameters directly.
 	 *
 	 * @param string $key
 	 * @param string $certificate

--- a/libasynql/src/poggit/libasynql/mysqli/MysqlSslCredentials.php
+++ b/libasynql/src/poggit/libasynql/mysqli/MysqlSslCredentials.php
@@ -56,11 +56,11 @@ class MysqlSslCredentials implements JsonSerializable{
 	/**
 	 * Constructs a new {@link MysqlSslCredentials} by passing parameters directly.
 	 *
-	 * @param string $key - The path name to the key file
-	 * @param string $certificate - The path name to the certificate file
-	 * @param string $caCertificate - The path name to the certificate authority file
-	 * @param string $caPath - The path name to a directory that contains trusted SSL CA certificates in PEM format
-	 * @param string $cipherAlgorithms - A list of allowable ciphers use for SSL encryption
+	 * @param string|null $key - The path name to the key file
+	 * @param string|null $certificate - The path name to the certificate file
+	 * @param string|null $caCertificate - The path name to the certificate authority file
+	 * @param string|null $caPath - The path name to a directory that contains trusted SSL CA certificates in PEM format
+	 * @param string|null $cipherAlgorithms - A list of allowable ciphers used for SSL encryption
 	 */
 	public function __construct(?string $key = null, ?string $certificate = null, ?string $caCertificate = null, ?string $caPath = null, ?string $cipherAlgorithms = null){
 		$this->key = $key;

--- a/libasynql/src/poggit/libasynql/mysqli/MysqlSslCredentials.php
+++ b/libasynql/src/poggit/libasynql/mysqli/MysqlSslCredentials.php
@@ -26,43 +26,43 @@ use JsonSerializable;
 use mysqli;
 
 class MysqlSslCredentials implements JsonSerializable{
-	/** @var string $key */
+	/** @var string|null $key */
 	private $key;
 	/** @var string $certificate */
 	private $certificate;
-	/** @var string $caCertificate */
+	/** @var string|null $caCertificate */
 	private $caCertificate;
-	/** @var string $caPath */
+	/** @var string|null $caPath */
 	private $caPath;
-	/** @var string $cipherAlgorithms */
+	/** @var string|null $cipherAlgorithms */
 	private $cipherAlgorithms;
 
 
 	/**
 	 * Creates a new {@link MysqlSslCredentials} instance from an array (e.g. from Config), with empty default values.
-	 * @param array       $array
+	 * @param array $array
 	 * @return MysqlSslCredentials
 	 */
 	public static function fromArray(array $array) : MysqlSslCredentials{
 		return new MysqlSslCredentials(
-			$array["key"] ?? "",
-			$array["certificate"] ?? "",
-			$array["ca-certificate"] ?? "",
-			$array["ca-path"] ?? "",
-			$array["cipher-algorithms"] ?? ""
+			$array["key"],
+			$array["certificate"],
+			$array["ca-certificate"],
+			$array["ca-path"],
+			$array["cipher-algorithms"],
 		);
 	}
 
 	/**
 	 * Constructs a new {@link MysqlSslCredentials} by passing parameters directly.
 	 *
-	 * @param string $key
-	 * @param string $certificate
-	 * @param string $caCertificate
-	 * @param string $caPath
-	 * @param string $cipherAlgorithms
+	 * @param string $key - The path name to the key file
+	 * @param string $certificate - The path name to the certificate file
+	 * @param string $caCertificate - The path name to the certificate authority file
+	 * @param string $caPath - The path name to a directory that contains trusted SSL CA certificates in PEM format
+	 * @param string $cipherAlgorithms - A list of allowable ciphers use for SSL encryption
 	 */
-	public function __construct(string $key = "", string $certificate = "", string $caCertificate = "", string $caPath = "", string $cipherAlgorithms = ""){
+	public function __construct(?string $key = null, ?string $certificate = null, ?string $caCertificate = null, ?string $caPath = null, ?string $cipherAlgorithms = null){
 		$this->key = $key;
 		$this->certificate = $certificate;
 		$this->caCertificate = $caCertificate;
@@ -91,7 +91,7 @@ class MysqlSslCredentials implements JsonSerializable{
 			"certificate" => $this->certificate,
 			"caCertificate" => $this->caCertificate,
 			"caPath" => $this->caPath,
-			"cipherAlgorithms" => $this->cipherAlgorithms
+			"cipherAlgorithms" => $this->cipherAlgorithms,
 		];
 	}
 }

--- a/libasynql/src/poggit/libasynql/mysqli/MysqlSslCredentials.php
+++ b/libasynql/src/poggit/libasynql/mysqli/MysqlSslCredentials.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * libasynql
+ *
+ * Copyright (C) 2018 SOFe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace poggit\libasynql\mysqli;
+
+use JsonSerializable;
+use mysqli;
+
+class MysqlSslCredentials implements JsonSerializable
+{
+	/** @var string $key */
+	private $key;
+	/** @var string $certificate */
+	private $certificate;
+	/** @var string $caCertificate */
+	private $caCertificate;
+	/** @var string $caPath */
+	private $caPath;
+	/** @var string $cipherAlgorithms */
+	private $cipherAlgorithms;
+
+
+	/**
+	 * Creates a new {@link MysqlSslCredentials} instance from an array (e.g. from Config), with empty default values.
+	 * @param array       $array
+	 * @return MysqlSslCredentials
+	 */
+	public static function fromArray(array $array): MysqlSslCredentials
+	{
+		return new MysqlSslCredentials(
+			$array["key"] ?? "",
+			$array["certificate"] ?? "",
+			$array["ca-certificate"] ?? "",
+			$array["ca-path"] ?? "",
+			$array["cipher-algorithms"] ?? ""
+		);
+	}
+
+	/**
+	 * Constructs a new {@link MysqlCredentials} by passing parameters directly.
+	 *
+	 * @param string $key
+	 * @param string $certificate
+	 * @param string $caCertificate
+	 * @param string $caPath
+	 * @param string $cipherAlgorithms
+	 */
+	public function __construct(string $key = "", string $certificate = "", string $caCertificate = "", string $caPath = "", string $cipherAlgorithms = "")
+	{
+		$this->key = $key;
+		$this->certificate = $certificate;
+		$this->caCertificate = $caCertificate;
+		$this->caPath = $caPath;
+		$this->cipherAlgorithms = $cipherAlgorithms;
+	}
+
+	/**
+	 * Sets the SSL credentials for the given {@link mysqli} instance.
+	 *
+	 * @param mysqli $mysqli
+	 */
+	public function applyToInstance(mysqli $mysqli): void
+	{
+		$mysqli->ssl_set(
+			$this->key,
+			$this->certificate,
+			$this->caCertificate,
+			$this->caPath,
+			$this->cipherAlgorithms
+		);
+	}
+
+	public function jsonSerialize(): array
+	{
+		return [
+			"key" => $this->key,
+			"certificate" => $this->certificate,
+			"caCertificate" => $this->caCertificate,
+			"caPath" => $this->caPath,
+			"cipherAlgorithms" => $this->cipherAlgorithms
+		];
+	}
+}

--- a/libasynql/src/poggit/libasynql/mysqli/MysqlSslCredentials.php
+++ b/libasynql/src/poggit/libasynql/mysqli/MysqlSslCredentials.php
@@ -45,11 +45,11 @@ class MysqlSslCredentials implements JsonSerializable{
 	 */
 	public static function fromArray(array $array) : MysqlSslCredentials{
 		return new MysqlSslCredentials(
-			$array["key"],
-			$array["certificate"],
-			$array["ca-certificate"],
-			$array["ca-path"],
-			$array["cipher-algorithms"],
+			$array["key"] ?? null,
+			$array["certificate"] ?? null,
+			$array["ca-certificate"] ?? null,
+			$array["ca-path"] ?? null,
+			$array["cipher-algorithms"] ?? null,
 		);
 	}
 

--- a/libasynql/src/poggit/libasynql/mysqli/MysqlSslCredentials.php
+++ b/libasynql/src/poggit/libasynql/mysqli/MysqlSslCredentials.php
@@ -43,8 +43,7 @@ class MysqlSslCredentials implements JsonSerializable{
 	 * @param array       $array
 	 * @return MysqlSslCredentials
 	 */
-	public static function fromArray(array $array): MysqlSslCredentials
-	{
+	public static function fromArray(array $array) : MysqlSslCredentials{
 		return new MysqlSslCredentials(
 			$array["key"] ?? "",
 			$array["certificate"] ?? "",
@@ -63,8 +62,7 @@ class MysqlSslCredentials implements JsonSerializable{
 	 * @param string $caPath
 	 * @param string $cipherAlgorithms
 	 */
-	public function __construct(string $key = "", string $certificate = "", string $caCertificate = "", string $caPath = "", string $cipherAlgorithms = "")
-	{
+	public function __construct(string $key = "", string $certificate = "", string $caCertificate = "", string $caPath = "", string $cipherAlgorithms = ""){
 		$this->key = $key;
 		$this->certificate = $certificate;
 		$this->caCertificate = $caCertificate;
@@ -77,8 +75,7 @@ class MysqlSslCredentials implements JsonSerializable{
 	 *
 	 * @param mysqli $mysqli
 	 */
-	public function applyToInstance(mysqli $mysqli): void
-	{
+	public function applyToInstance(mysqli $mysqli) : void{
 		$mysqli->ssl_set(
 			$this->key,
 			$this->certificate,
@@ -88,8 +85,7 @@ class MysqlSslCredentials implements JsonSerializable{
 		);
 	}
 
-	public function jsonSerialize(): array
-	{
+	public function jsonSerialize() : array{
 		return [
 			"key" => $this->key,
 			"certificate" => $this->certificate,


### PR DESCRIPTION
# Overview
Before this pull request, libasynql lacked the ability to connect to a MySQL server using an SSL connection (as seen by #80). This pull request aims to resolve that by adding a simple wrapper using an SSL credentials class (`MysqlSslCredentials`) and matching configuration options. These configuration options can be used like so:
```yml
database:
  type: mysql
  mysql:
    # ...
    ssl:
      key: ""
      certificate: ""
      ca-certificate: ""
      ca-path: ""
      cipher-algorithms: ""
```
# Testing
Using two instances, one with SSL and one without SSL, I was able to confirm that the functionality remains the same. Furthermore, errors are properly thrown if an SSL instance is not given the proper credentials.

# Backwards Compatibility
Compatibility for the library remains the same as the SSL credentials are nullable and prefilled with a null value for both `fromArray` and the constructor.