### PR TITLE
Fixed thread crashing by disabling mysqli report

### DIFF
--- a/libasynql/src/poggit/libasynql/mysqli/MysqliThread.php
+++ b/libasynql/src/poggit/libasynql/mysqli/MysqliThread.php
@@ -93,7 +93,14 @@ class MysqliThread extends SqlSlaveThread{
 		assert($mysqli instanceof mysqli);
 		/** @var MysqlCredentials $cred */
 		$cred = unserialize($this->credentials);
-		if(!$mysqli->ping()){
+		$ping = false;
+
+		mysqli_report(MYSQLI_REPORT_OFF);
+		try {
+			$ping = @$mysqli->ping();
+		} catch (\mysqli_sql_exception $err){}
+		
+		if(!$ping){
 			$success = false;
 			$attempts = 0;
 			do{


### PR DESCRIPTION
This fix is working, but still, we should get a way to receive the error because when `mysqli->ping()` returns false, the thread crashes with the error instead of returning it even if you use try/catch.