### PR TITLE
Fix MysqlCredentials way of handling connection errors.

### DIFF
--- a/libasynql/src/poggit/libasynql/mysqli/MysqlCredentials.php
+++ b/libasynql/src/poggit/libasynql/mysqli/MysqlCredentials.php
@@ -118,9 +118,6 @@ class MysqlCredentials implements JsonSerializable{
 		}catch (mysqli_sql_exception $e){
 			throw new SqlError(SqlError::STAGE_CONNECT, $e->getMessage());
 		}
-		if($mysqli->connect_error){
-			throw new SqlError(SqlError::STAGE_CONNECT, $mysqli->connect_error);
-		}
 		return $mysqli;
 	}
 

--- a/libasynql/src/poggit/libasynql/mysqli/MysqlCredentials.php
+++ b/libasynql/src/poggit/libasynql/mysqli/MysqlCredentials.php
@@ -24,6 +24,7 @@ namespace poggit\libasynql\mysqli;
 
 use JsonSerializable;
 use mysqli;
+use mysqli_sql_exception;
 use poggit\libasynql\ConfigException;
 use poggit\libasynql\SqlError;
 use function strlen;
@@ -112,7 +113,11 @@ class MysqlCredentials implements JsonSerializable{
 		if($this->sslCredentials !== null){
 			$this->sslCredentials->applyToInstance($mysqli);
 		}
-		@mysqli_real_connect($mysqli, $this->host, $this->username, $this->password, $this->schema, $this->port, $this->socket);
+		try {
+			@mysqli_real_connect($mysqli, $this->host, $this->username, $this->password, $this->schema, $this->port, $this->socket);
+		}catch (mysqli_sql_exception $e){
+			throw new SqlError(SqlError::STAGE_CONNECT, $e->getMessage());
+		}
 		if($mysqli->connect_error){
 			throw new SqlError(SqlError::STAGE_CONNECT, $mysqli->connect_error);
 		}


### PR DESCRIPTION
It may seem weird if you look at the code, but `mysqli->connect_error` is still used. Hence, we are sure that we catch any type of mysqli error, whether it is thrown or not. 
(PHP's mysqli seem to bug this out: if you're doing first connection, an exception will be thrown. If it's a reconnect situation, no exception is thrown, you are able to check `connect_error` to decide if an error has happened.

Before PR:
![image](https://github.com/poggit/libasynql/assets/32373441/baa3a058-8ed5-498a-87af-540537715a3f)
(you're stuck with frozen main thread and the only way to get out is to CTRL-Z it)

After PR:
![image](https://github.com/poggit/libasynql/assets/32373441/5f46af02-6251-416b-8f13-ab193d1a36ee)
(an error is correctly catched, results into dataConnector being null, and infected plugin is able to check if connection is not successful)