### PR TITLE
Prevent MysqliThread fainted on select query return false

### DIFF
--- a/libasynql/src/poggit/libasynql/mysqli/MysqliThread.php
+++ b/libasynql/src/poggit/libasynql/mysqli/MysqliThread.php
@@ -153,6 +153,9 @@ class MysqliThread extends SqlSlaveThread{
 					return new SqlResult();
 
 				case SqlThread::MODE_SELECT:
+					if($result === false){
+						throw new SqlError(SqlError::STAGE_EXECUTE, $mysqli->error, $query, $params);
+					}
 					$ret = $this->toSelectResult($result);
 					$result->close();
 					return $ret;
@@ -199,6 +202,9 @@ class MysqliThread extends SqlSlaveThread{
 
 				case SqlThread::MODE_SELECT:
 					$set = $stmt->get_result();
+					if($set === false){
+						throw new SqlError(SqlError::STAGE_EXECUTE, $mysqli->error, $query, $params);
+					}
 					$ret = $this->toSelectResult($set);
 					$set->close();
 					return $ret;


### PR DESCRIPTION
In MariaDB, a MySQL alternative, there is a RETURNING statement in INSERT statements. (I find it safer and simpler than INSERT+SELECT)

I am using `DataConnector::asyncSelect()` to receive this response. However, if the query fails due to an error, the MysqliThread fainted without proccessing the generator... 
This makes it impossible for the code to determine the success or progress of the operation.

Before PR:
![image](https://github.com/poggit/libasynql/assets/13284800/80734d15-d9a6-41d3-9889-611d4c8bea6c)
(MysqliThread goes down and after that, the correct query request doesn't work either.)

After PR:
![image](https://github.com/poggit/libasynql/assets/13284800/78716866-a0e8-437a-b6df-cfb7ea90bd74)
(The error is throw correctly, and now can catch it to process it.)

---

Tested `test.sql` code
```sql
-- #! mysql
-- # { test1
CREATE TABLE IF NOT EXISTS test
(
    id    INT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
    value INT UNSIGNED NOT NULL
);
-- # }
-- # { test2
INSERT INTO test (value)
VALUES (-9999)
RETURNING id, value;
-- # }
```

Tested php code
```php
$conn = libasynql::create($this, $this->getConfig(), ["mysql" => "test.sql"]);
Await::f2c(static function() use ($conn){
    yield from $conn->asyncGeneric("test1");
    var_dump(yield from $conn->asyncSelect("test2"));
});
```

