### PR TITLE
Fix: Support numeric column names in SQLite3 queries

### DIFF
--- a/libasynql/src/poggit/libasynql/result/SqlColumnInfo.php
+++ b/libasynql/src/poggit/libasynql/result/SqlColumnInfo.php
@@ -34,12 +34,12 @@ class SqlColumnInfo{
 	private $name;
 	private $type;
 
-	public function __construct(string $name, string $type){
+	public function __construct(string|int $name, string $type){
 		$this->name = $name;
 		$this->type = $type;
 	}
 
-	public function getName() : string{
+	public function getName() : string|int{
 		return $this->name;
 	}
 

--- a/libasynql/src/poggit/libasynql/result/SqlColumnInfo.php
+++ b/libasynql/src/poggit/libasynql/result/SqlColumnInfo.php
@@ -34,12 +34,12 @@ class SqlColumnInfo{
 	private $name;
 	private $type;
 
-	public function __construct(string|int $name, string $type){
+	public function __construct(string $name, string $type){
 		$this->name = $name;
 		$this->type = $type;
 	}
 
-	public function getName() : string|int{
+	public function getName() : string{
 		return $this->name;
 	}
 

--- a/libasynql/src/poggit/libasynql/sqlite3/Sqlite3Thread.php
+++ b/libasynql/src/poggit/libasynql/sqlite3/Sqlite3Thread.php
@@ -125,7 +125,7 @@ class Sqlite3Thread extends SqlSlaveThread{
 							SQLITE3_NULL => SqlColumnInfo::TYPE_NULL,
 						];
 						$value = $row[$columnName];
-						$colInfo[$i] = new SqlColumnInfo($columnName, $columnTypeMap[$result->columnType($i)]);
+						$colInfo[$i] = new SqlColumnInfo((string) $columnName, $columnTypeMap[$result->columnType($i)]);
 						if($colInfo[$i]->getType() === SqlColumnInfo::TYPE_FLOAT){
 							if($value === "NAN"){
 								$value = NAN;


### PR DESCRIPTION
SQLite3 may return numeric column names for queries using literal values without explicit aliases. This causes a type error when `SqlColumnInfo` expects only string column names.

Error:
```
[CRITICAL] Laith98Dev\RankShop\libs\poggit\libasynql\result\SqlColumnInfo::__construct(): 
Argument #1 ($name) must be of type string, int given, called in 
/home/ubuntu/pmserver/plugins/RankShop/src/Laith98Dev/RankShop/libs/poggit/libasynql/sqlite3/Sqlite3Thread.php on line 128
#0 /home/ubuntu/pmserver/plugins/RankShop/src/Laith98Dev/RankShop/libs/poggit/libasynql/sqlite3/Sqlite3Thread.php(128): 
Laith98Dev\RankShop\libs\poggit\libasynql\result\SqlColumnInfo->__construct(1, 'int')
#1 /home/ubuntu/pmserver/plugins/RankShop/src/Laith98Dev/RankShop/libs/poggit/libasynql/base/SqlSlaveThread.php(86): 
Laith98Dev\RankShop\libs\poggit\libasynql\sqlite3\Sqlite3Thread->executeQuery(Object(SQLite3), 3, 'SELECT 1\nFROM p...', Array)
#2 phar:///tmp/PocketMine-MP-phar-cache-0/PMMP1W9s4W.tar/src/thread/CommonThreadPartsTrait.php(130): 
Laith98Dev\RankShop\libs\poggit\libasynql\base\SqlSlaveThread->onRun()
#3 [internal function]: pocketmine\thread\Thread->run()
#4 {main}
```

Example query:
```sql
-- #  { has-rank
-- #     :player_xuid string
-- #     :rank_id int
SELECT 1
FROM player_ranks
WHERE player_xuid = :player_xuid
  AND rank_id = :rank_id
LIMIT 1;
-- #  }
```
During testing, this issue did not occur with MySQL, as MySQL always returns column names as strings.
However, SQLite3 returns a literal value such as 1 as the column name, which may be an integer instead of a string.
This behavior is specific to SQLite3 and causes the observed issue.